### PR TITLE
4.0.6 - Remove API 14 PHPicker due to incompatibility with our image cropper.

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -20,11 +20,6 @@
 @interface ImagePickerManager (UIAdaptivePresentationControllerDelegate) <UIAdaptivePresentationControllerDelegate>
 @end
 
-#if __has_include(<PhotosUI/PHPicker.h>)
-@interface ImagePickerManager (PHPickerViewControllerDelegate) <PHPickerViewControllerDelegate>
-@end
-#endif
-
 @implementation ImagePickerManager
 
 NSString *errCameraUnavailable = @"camera_unavailable";
@@ -60,20 +55,6 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
     }
     
     self.options = options;
-
-#if __has_include(<PhotosUI/PHPicker.h>)
-    if (@available(iOS 14, *)) {
-        if (target == library) {
-            PHPickerConfiguration *configuration = [ImagePickerUtils makeConfigurationFromOptions:options target:target];
-            PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:configuration];
-            picker.delegate = self;
-            picker.presentationController.delegate = self;
-
-            [self showPickerViewController:picker];
-            return;
-        }
-    }
-#endif
     
     UIImagePickerController *picker = [[UIImagePickerController alloc] init];
     [ImagePickerUtils setupPickerFromOptions:picker options:self.options target:target];
@@ -346,60 +327,3 @@ RCT_EXPORT_METHOD(launchImageLibrary:(NSDictionary *)options callback:(RCTRespon
 }
 
 @end
-
-#if __has_include(<PhotosUI/PHPicker.h>)
-@implementation ImagePickerManager (PHPickerViewControllerDelegate)
-
-- (void)picker:(PHPickerViewController *)picker didFinishPicking:(NSArray<PHPickerResult *> *)results API_AVAILABLE(ios(14))
-{
-    [picker dismissViewControllerAnimated:YES completion:nil];
-
-    if (results.count == 0) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            self.callback(@[@{@"didCancel": @YES}]);
-        });
-        return;
-    }
-
-    dispatch_group_t completionGroup = dispatch_group_create();
-    NSMutableArray<NSDictionary *> *assets = [[NSMutableArray alloc] initWithCapacity:results.count];
-
-    for (PHPickerResult *result in results) {
-        NSItemProvider *provider = result.itemProvider;
-        dispatch_group_enter(completionGroup);
-
-        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
-            [provider loadDataRepresentationForTypeIdentifier:(NSString *)kUTTypeImage completionHandler:^(NSData * _Nullable data, NSError * _Nullable error) {
-                UIImage *image = [[UIImage alloc] initWithData:data];
-
-                [assets addObject:[self mapImageToAsset:image data:data]];
-                dispatch_group_leave(completionGroup);
-            }];
-        }
-
-        if ([provider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeMovie]) {
-            [provider loadFileRepresentationForTypeIdentifier:(NSString *)kUTTypeMovie completionHandler:^(NSURL * _Nullable url, NSError * _Nullable error) {
-                [assets addObject:[self mapVideoToAsset:url error:nil]];
-                dispatch_group_leave(completionGroup);
-            }];
-        }
-    }
-
-    dispatch_group_notify(completionGroup, dispatch_get_main_queue(), ^{
-        //  mapVideoToAsset can fail and return nil.
-        for (NSDictionary *asset in assets) {
-            if (nil == asset) {
-                self.callback(@[@{@"errorCode": errOthers}]);
-                return;
-            }
-        }
-
-        NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
-        [response setObject:assets forKey:@"assets"];
-
-        self.callback(@[response]);
-    });
-}
-
-@end
-#endif


### PR DESCRIPTION
* Removes a recent addition of API 14 support for this library as it does not play well with our cropping library (semi-related is this removal of the field we used to use) https://github.com/react-native-image-picker/react-native-image-picker/issues/1536

* We would normally just want to use a single library but currently we have some bugs  https://github.com/discord/discord/pull/48038 that prevent us from consolidating.

* We had to bump this library to get support for RN Android https://github.com/discord/discord/pull/50489 - overall though we still have bumped to a much more recent version of this library and are just missing this iOS 14 functionality now.

---

This PR is not meant to merge and is something I'd like us to revisit in the future when our cropping library is updated.