### PR TITLE
[ios] Upgrade to more recent lib code, and enable multi- and pre-selection

### DIFF
--- a/ios/ImagePickerManager.h
+++ b/ios/ImagePickerManager.h
@@ -1,5 +1,6 @@
 #import <React/RCTBridgeModule.h>
 #import <UIKit/UIKit.h>
+#import <React/RCTConvert.h>
 
 typedef NS_ENUM(NSInteger, RNImagePickerTarget) {
   camera = 1,

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -456,6 +456,9 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(
 
         NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
         response[@"assets"] = assets;
+        if (@available(iOS 15, *)) {
+            response[@"replaceSelection"] = @(YES);
+        }
         self.callback(@[response]);
     };
 
@@ -571,7 +574,9 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(
 
         NSMutableDictionary* response = [[NSMutableDictionary alloc] init];
         [response setObject:assets forKey:@"assets"];
-
+        if (@available(iOS 15, *)) {
+            response[@"replaceSelection"] = @(YES);
+        }
         self.callback(@[ response ]);
     });
 }

--- a/ios/ImagePickerUtils.h
+++ b/ios/ImagePickerUtils.h
@@ -9,6 +9,8 @@
 
 + (void)setupPickerFromOptions:(UIImagePickerController *)picker options:(NSDictionary *)options target:(RNImagePickerTarget)target;
 
++ (UIModalPresentationStyle) getPresentationStyle:(id)presentationStyle;
+
 + (PHPickerConfiguration *)makeConfigurationFromOptions:(NSDictionary *)options target:(RNImagePickerTarget)target API_AVAILABLE(ios(14));
 
 + (NSString*)getFileType:(NSData*)imageData;


### PR DESCRIPTION
This PR does a few things:
1. Brings the iOS code closer to the latest version of the `react-native-image-picker`, which has a couple bug fixes and image-data improvements.
2. Enables use of iOS 14+'s `PHPickerViewController`, along with its preselection capabilities.
3. Thoroughly includes `id` as the "asset local identifier" in the response's assets.