### PR TITLE
Catch IOException on method that now throws on Android 33

### DIFF
--- a/android/src/main/java/com/imagepicker/VideoMetadata.java
+++ b/android/src/main/java/com/imagepicker/VideoMetadata.java
@@ -43,7 +43,11 @@ public class VideoMetadata extends Metadata {
       this.height = bitmap.getHeight();
     }
 
-    metadataRetriever.release();
+    try {
+      metadataRetriever.release();
+    } catch (IOException e) {
+      Log.e("RNIP", "Could not release metadata retriever: " + e.getMessage());
+    }
   }
 
   public int getBitrate() {


### PR DESCRIPTION
Compiling against Android 33 now causes this method to throw an IOException and will not compile unless caught appropriately