### PR TITLE
fix(android): migrate to Activity Result API to resolve New Architecture crashes

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -11,7 +11,6 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.Lifecycle;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Callback;
@@ -66,8 +65,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     @Override
     public void onHostResume() {
         Activity currentActivity = getCurrentActivity();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            currentActivity instanceof FragmentActivity fragmentActivity) {
+        if (currentActivity instanceof FragmentActivity fragmentActivity) {
             initializeLaunchers(fragmentActivity);
         }
     }
@@ -93,29 +91,25 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         // Only register if we haven't already for this activity
         if (currentFragmentActivity != activity || cameraLauncher == null) {
             try {
-                // Check if we can register (activity must be at least CREATED)
-                if (activity.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED)) {
-                    currentFragmentActivity = activity;
+                currentFragmentActivity = activity;
 
-                    cameraLauncher = activity.registerForActivityResult(
-                            new ActivityResultContracts.StartActivityForResult(),
-                            result -> {
-                                int requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
-                                if (this.options != null && this.options.mediaType.equals(mediaTypeVideo)) {
-                                    requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
-                                }
-                                onActivityResult(activity, requestCode, result.getResultCode(), result.getData());
+                cameraLauncher = activity.registerForActivityResult(
+                        new ActivityResultContracts.StartActivityForResult(),
+                        result -> {
+                            int requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
+                            if (this.options != null && this.options.mediaType.equals(mediaTypeVideo)) {
+                                requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
                             }
-                    );
+                            onActivityResult(activity, requestCode, result.getResultCode(), result.getData());
+                        }
+                );
 
-                    libraryLauncher = activity.registerForActivityResult(
-                            new ActivityResultContracts.StartActivityForResult(),
-                            result -> {
-                                onActivityResult(activity, REQUEST_LAUNCH_LIBRARY, result.getResultCode(), result.getData());
-                            }
-                    );
-
-                }
+                libraryLauncher = activity.registerForActivityResult(
+                        new ActivityResultContracts.StartActivityForResult(),
+                        result -> {
+                            onActivityResult(activity, REQUEST_LAUNCH_LIBRARY, result.getResultCode(), result.getData());
+                        }
+                );
             } catch (IllegalStateException e) {
                 // Failed to register - activity in wrong state
             }
@@ -251,8 +245,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             this.callback = null;
         }
     }
-
-
 
     void onAssetsObtained(List<Uri> fileUris) {
         try {

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -56,7 +56,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     private ActivityResultLauncher<Intent> libraryLauncher;
     private FragmentActivity currentFragmentActivity;
 
-            public ImagePickerModule(ReactApplicationContext reactContext) {
+    public ImagePickerModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.reactContext.addActivityEventListener(this);
@@ -78,22 +78,16 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     @Override
     public void onHostDestroy() {}
 
-    @Override
-    public void initialize() {
-        super.initialize();
-    }
-
-
     @NonNull
     @Override
     public String getName() {
         return NAME;
     }
 
-        /**
+    /**
      * Initialize launchers when we have access to a FragmentActivity during proper lifecycle
      */
-        private void initializeLaunchers(FragmentActivity activity) {
+    private void initializeLaunchers(FragmentActivity activity) {
         if (activity == null) return;
 
         // Only register if we haven't already for this activity
@@ -104,66 +98,27 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
                     currentFragmentActivity = activity;
 
                     cameraLauncher = activity.registerForActivityResult(
-                        new ActivityResultContracts.StartActivityForResult(),
-                        result -> {
-                            int requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
-                            if (this.options != null && this.options.mediaType.equals(mediaTypeVideo)) {
-                                requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
+                            new ActivityResultContracts.StartActivityForResult(),
+                            result -> {
+                                int requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
+                                if (this.options != null && this.options.mediaType.equals(mediaTypeVideo)) {
+                                    requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
+                                }
+                                onActivityResult(activity, requestCode, result.getResultCode(), result.getData());
                             }
-                            onActivityResult(activity, requestCode, result.getResultCode(), result.getData());
-                        }
                     );
 
                     libraryLauncher = activity.registerForActivityResult(
-                        new ActivityResultContracts.StartActivityForResult(),
-                        result -> {
-                            onActivityResult(activity, REQUEST_LAUNCH_LIBRARY, result.getResultCode(), result.getData());
-                        }
+                            new ActivityResultContracts.StartActivityForResult(),
+                            result -> {
+                                onActivityResult(activity, REQUEST_LAUNCH_LIBRARY, result.getResultCode(), result.getData());
+                            }
                     );
 
                 }
             } catch (IllegalStateException e) {
                 // Failed to register - activity in wrong state
             }
-        }
-    }
-
-    @Override
-    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        // onActivityResult is called even when ActivityNotFoundException occurs
-        if (!isValidRequestCode(requestCode) || (this.callback == null)) {
-            return;
-        }
-
-        if (resultCode != Activity.RESULT_OK) {
-            if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
-                deleteFile(fileUri);
-            }
-            callback.invoke(getCancelMap());
-            this.callback = null;
-            return;
-        }
-
-        switch (requestCode) {
-            case REQUEST_LAUNCH_IMAGE_CAPTURE:
-                if (options.saveToPhotos) {
-                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "photo");
-                }
-
-                onAssetsObtained(Collections.singletonList(fileUri));
-                break;
-
-            case REQUEST_LAUNCH_LIBRARY:
-                onAssetsObtained(collectUrisFromData(data));
-                break;
-
-            case REQUEST_LAUNCH_VIDEO_CAPTURE:
-                if (options.saveToPhotos) {
-                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "video");
-                }
-
-                onAssetsObtained(Collections.singletonList(fileUri));
-                break;
         }
     }
 
@@ -259,18 +214,18 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         boolean isVideo = this.options.mediaType.equals(mediaTypeVideo);
         boolean isMixed = this.options.mediaType.equals(mediaTypeMixed);
 
-        if(isSingleSelect && (isPhoto || isVideo)) {
+        if (isSingleSelect && (isPhoto || isVideo)) {
             libraryIntent = new Intent(Intent.ACTION_PICK);
         } else {
             libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);
             libraryIntent.addCategory(Intent.CATEGORY_OPENABLE);
         }
 
-        if(!isSingleSelect) {
+        if (!isSingleSelect) {
             libraryIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
         }
 
-        if(isPhoto) {
+        if (isPhoto) {
             libraryIntent.setType("image/*");
         } else if (isVideo) {
             libraryIntent.setType("video/*");
@@ -309,10 +264,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         }
     }
 
-
-    @Override
-    public void onNewIntent(Intent intent) { }
-
     @Override
     public void invalidate() {
         super.invalidate();
@@ -329,4 +280,46 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             currentFragmentActivity = null;
         }
     }
+
+    @Override
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        // onActivityResult is called even when ActivityNotFoundException occurs
+        if (!isValidRequestCode(requestCode) || (this.callback == null)) {
+            return;
+        }
+
+        if (resultCode != Activity.RESULT_OK) {
+            if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
+                deleteFile(fileUri);
+            }
+            callback.invoke(getCancelMap());
+            this.callback = null;
+            return;
+        }
+
+        switch (requestCode) {
+            case REQUEST_LAUNCH_IMAGE_CAPTURE:
+                if (options.saveToPhotos) {
+                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "photo");
+                }
+
+                onAssetsObtained(Collections.singletonList(fileUri));
+                break;
+
+            case REQUEST_LAUNCH_LIBRARY:
+                onAssetsObtained(collectUrisFromData(data));
+                break;
+
+            case REQUEST_LAUNCH_VIDEO_CAPTURE:
+                if (options.saveToPhotos) {
+                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "video");
+                }
+
+                onAssetsObtained(Collections.singletonList(fileUri));
+                break;
+        }
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {}
 }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -7,8 +7,15 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -25,7 +32,7 @@ import static com.imagepicker.Utils.*;
 import javax.annotation.Nullable;
 
 @ReactModule(name = ImagePickerModule.NAME)
-public class ImagePickerModule extends ReactContextBaseJavaModule implements ActivityEventListener {
+public class ImagePickerModule extends ReactContextBaseJavaModule implements ActivityEventListener, LifecycleEventListener {
     static final String NAME = "ImagePickerManager";
 
     // Public to let consuming apps hook into the image picker response
@@ -44,15 +51,120 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     @Nullable
     UUID identifier;
 
-    public ImagePickerModule(ReactApplicationContext reactContext) {
+    // Pre-registered launchers for Activity Result API
+    private ActivityResultLauncher<Intent> cameraLauncher;
+    private ActivityResultLauncher<Intent> libraryLauncher;
+    private FragmentActivity currentFragmentActivity;
+
+            public ImagePickerModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.reactContext.addActivityEventListener(this);
+        this.reactContext.addLifecycleEventListener(this);
     }
 
     @Override
+    public void onHostResume() {
+        Activity currentActivity = getCurrentActivity();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            currentActivity instanceof FragmentActivity fragmentActivity) {
+            initializeLaunchers(fragmentActivity);
+        }
+    }
+
+    @Override
+    public void onHostPause() {}
+
+    @Override
+    public void onHostDestroy() {}
+
+    @Override
+    public void initialize() {
+        super.initialize();
+    }
+
+
+    @NonNull
+    @Override
     public String getName() {
         return NAME;
+    }
+
+        /**
+     * Initialize launchers when we have access to a FragmentActivity during proper lifecycle
+     */
+        private void initializeLaunchers(FragmentActivity activity) {
+        if (activity == null) return;
+
+        // Only register if we haven't already for this activity
+        if (currentFragmentActivity != activity || cameraLauncher == null) {
+            try {
+                // Check if we can register (activity must be at least CREATED)
+                if (activity.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED)) {
+                    currentFragmentActivity = activity;
+
+                    cameraLauncher = activity.registerForActivityResult(
+                        new ActivityResultContracts.StartActivityForResult(),
+                        result -> {
+                            int requestCode = REQUEST_LAUNCH_IMAGE_CAPTURE;
+                            if (this.options != null && this.options.mediaType.equals(mediaTypeVideo)) {
+                                requestCode = REQUEST_LAUNCH_VIDEO_CAPTURE;
+                            }
+                            onActivityResult(activity, requestCode, result.getResultCode(), result.getData());
+                        }
+                    );
+
+                    libraryLauncher = activity.registerForActivityResult(
+                        new ActivityResultContracts.StartActivityForResult(),
+                        result -> {
+                            onActivityResult(activity, REQUEST_LAUNCH_LIBRARY, result.getResultCode(), result.getData());
+                        }
+                    );
+
+                }
+            } catch (IllegalStateException e) {
+                // Failed to register - activity in wrong state
+            }
+        }
+    }
+
+    @Override
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        // onActivityResult is called even when ActivityNotFoundException occurs
+        if (!isValidRequestCode(requestCode) || (this.callback == null)) {
+            return;
+        }
+
+        if (resultCode != Activity.RESULT_OK) {
+            if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
+                deleteFile(fileUri);
+            }
+            callback.invoke(getCancelMap());
+            this.callback = null;
+            return;
+        }
+
+        switch (requestCode) {
+            case REQUEST_LAUNCH_IMAGE_CAPTURE:
+                if (options.saveToPhotos) {
+                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "photo");
+                }
+
+                onAssetsObtained(Collections.singletonList(fileUri));
+                break;
+
+            case REQUEST_LAUNCH_LIBRARY:
+                onAssetsObtained(collectUrisFromData(data));
+                break;
+
+            case REQUEST_LAUNCH_VIDEO_CAPTURE:
+                if (options.saveToPhotos) {
+                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "video");
+                }
+
+                onAssetsObtained(Collections.singletonList(fileUri));
+                break;
+        }
     }
 
     @ReactMethod
@@ -113,9 +225,16 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
 
         try {
-            currentActivity.startActivityForResult(cameraIntent, requestCode);
+            if (cameraLauncher != null) {
+                cameraLauncher.launch(cameraIntent);
+            } else {
+                currentActivity.startActivityForResult(cameraIntent, requestCode);
+            }
         } catch (ActivityNotFoundException e) {
             callback.invoke(getErrorMap(errOthers, e.getMessage()));
+            this.callback = null;
+        } catch (Exception e) {
+            callback.invoke(getErrorMap(errOthers, "Failed to launch camera: " + e.getMessage()));
             this.callback = null;
         }
     }
@@ -162,13 +281,23 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
             libraryIntent.setType("*/*");
         }
 
+        Intent chooserIntent = Intent.createChooser(libraryIntent, null);
         try {
-            currentActivity.startActivityForResult(Intent.createChooser(libraryIntent, null), requestCode);
+            if (libraryLauncher != null) {
+                libraryLauncher.launch(chooserIntent);
+            } else {
+                currentActivity.startActivityForResult(chooserIntent, requestCode);
+            }
         } catch (ActivityNotFoundException e) {
             callback.invoke(getErrorMap(errOthers, e.getMessage()));
             this.callback = null;
+        } catch (Exception e) {
+            callback.invoke(getErrorMap(errOthers, "Failed to launch library: " + e.getMessage()));
+            this.callback = null;
         }
     }
+
+
 
     void onAssetsObtained(List<Uri> fileUris) {
         try {
@@ -180,46 +309,24 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         }
     }
 
-    @Override
-    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-
-        // onActivityResult is called even when ActivityNotFoundException occurs
-        if (!isValidRequestCode(requestCode) || (this.callback == null)) {
-            return;
-        }
-
-        if (resultCode != Activity.RESULT_OK) {
-            if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
-                deleteFile(fileUri);
-            }
-            callback.invoke(getCancelMap());
-            this.callback = null;
-            return;
-        }
-
-        switch (requestCode) {
-            case REQUEST_LAUNCH_IMAGE_CAPTURE:
-                if (options.saveToPhotos) {
-                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "photo");
-                }
-
-                onAssetsObtained(Collections.singletonList(fileUri));
-                break;
-
-            case REQUEST_LAUNCH_LIBRARY:
-                onAssetsObtained(collectUrisFromData(data));
-                break;
-
-            case REQUEST_LAUNCH_VIDEO_CAPTURE:
-                if (options.saveToPhotos) {
-                    saveToPublicDirectory(cameraCaptureURI, identifier, reactContext, "video");
-                }
-
-                onAssetsObtained(Collections.singletonList(fileUri));
-                break;
-        }
-    }
 
     @Override
     public void onNewIntent(Intent intent) { }
+
+    @Override
+    public void invalidate() {
+        super.invalidate();
+        // Clean up launchers to prevent memory leaks
+        if (cameraLauncher != null) {
+            cameraLauncher.unregister();
+            cameraLauncher = null;
+        }
+        if (libraryLauncher != null) {
+            libraryLauncher.unregister();
+            libraryLauncher = null;
+        }
+        if (currentFragmentActivity != null) {
+            currentFragmentActivity = null;
+        }
+    }
 }


### PR DESCRIPTION
## Root Cause
The crash occurred because startActivityForResult triggers Android's cancelInputsAndStartExitTransition() → dispatchCancelPendingInputEvents() flow. With New Architecture (Fabric), views can become null during this traversal due to aggressive view recycling and different lifecycle management, causing NPEs when dispatchCancelPendingInputEvents() is called on null views.

## Solution
- Replace startActivityForResult with registerForActivityResult which bypasses the problematic input cancellation flow
- Initialize launchers in onHostResume when FragmentActivity is available
- Fall back to old API when launchers aren't ready

## Why This Fixes It
registerForActivityResult doesn't trigger cancelInputsAndStartExitTransition(). Instead, it uses modern Android input handling that's compatible with New Architecture's view lifecycle management.

## Compatibility
- API 21+: Uses Activity Result API
- API <21: Falls back to startActivityForResult
- Maintains same public API surface

ticket: https://app.asana.com/1/236888843494340/project/1199705967702853/task/1211009786491594?focus=true