### PR TITLE
add forceGetContent to fix Meta Quest

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -208,7 +208,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
         boolean isVideo = this.options.mediaType.equals(mediaTypeVideo);
         boolean isMixed = this.options.mediaType.equals(mediaTypeMixed);
 
-        if (isSingleSelect && (isPhoto || isVideo)) {
+        // ACTION_PICK is not supported on Meta Quest devices. We force the use of ACTION_GET_CONTENT.
+        // This is fixed in the latest version of the library (tested on 8.2.1).
+        if (isSingleSelect && (isPhoto || isVideo) && !this.options.forceGetContent) {
             libraryIntent = new Intent(Intent.ACTION_PICK);
         } else {
             libraryIntent = new Intent(Intent.ACTION_GET_CONTENT);

--- a/android/src/main/java/com/imagepicker/Options.java
+++ b/android/src/main/java/com/imagepicker/Options.java
@@ -14,6 +14,7 @@ public class Options {
     Boolean saveToPhotos;
     int durationLimit;
     Boolean useFrontCamera = false;
+    Boolean forceGetContent = false;
     String mediaType;
 
 
@@ -30,6 +31,10 @@ public class Options {
 
         if (options.getString("cameraType").equals("front")) {
             useFrontCamera = true;
+        }
+
+        if (options.hasKey("forceGetContent") && options.getBoolean("forceGetContent")) {
+            forceGetContent = true;
         }
 
         quality = (int) (options.getDouble("quality") * 100);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export interface ImageLibraryOptions {
   videoQuality?: AndroidVideoOptions | iOSVideoOptions;
   includeBase64?: boolean;
   includeExtra?: boolean;
+  /**
+   * Android only. Forces the use of ACTION_GET_CONTENT intent instead of ACTION_PICK.
+   * It is used on Meta Quest devices since ACTION_PICK is not supported.
+   */
+  forceGetContent?: boolean;
 }
 
 export interface CameraOptions


### PR DESCRIPTION
This PR adds a `forceGetContent` option for Meta Quest devices, since `ACTION_PICK` is not supported on those devices. As a result, we force the use of `ACTION_GET_CONTENT`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212484621099352