### PR TITLE
fix(ios): prevent duplicate cancel callbacks in image picker

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -27,7 +27,7 @@ NSString *errPermission = @"permission";
 NSString *errOthers = @"others";
 RNImagePickerTarget target;
 
-photoSelected = NO;
+bool photoSelected = NO;
 
 RCT_EXPORT_MODULE();
 
@@ -506,6 +506,8 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
+    if (photoSelected == YES) { return; }
+    photoSelected = YES;
     dispatch_async(dispatch_get_main_queue(), ^{
         [picker dismissViewControllerAnimated:YES completion:^{
             self.callback(@[@{@"didCancel": @YES}]);
@@ -519,6 +521,8 @@ CGImagePropertyOrientation CGImagePropertyOrientationForUIImageOrientation(
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
+    if (photoSelected == YES) { return; }
+    photoSelected = YES;
     self.callback(@[@{@"didCancel": @YES}]);
 }
 


### PR DESCRIPTION
I don't have a repro; this is a bit of a guess at a fix for the Sentry issue

- Sentry issue: https://discord.sentry.io/issues/7518688525/events/829fb20ae3c74e97ba3284deee3bc8e5/?project=230973
- moves patch changes to the fork (introduced in https://github.com/discord/discord-archive-2024/pull/183085)
- upstream issue (not solved): https://github.com/react-native-image-picker/react-native-image-picker/issues/2390
- the solution taken from: https://github.com/react-native-image-picker/react-native-image-picker/issues/2390#issuecomment-4523712882

## AI-driven repro scenario when it could happen:

The race requires the async photo load to still be in-flight when the dismiss fires — it won't happen on fast local photos.

1. Use an iCloud photo that is **not** downloaded locally (look for the cloud icon in Photos).
2. Enable New Architecture (`NOBRIDGE` mode).
3. Open the image picker, tap the iCloud photo to select it, then **immediately swipe down** before the download completes.
4. Without the patch: the `dispatch_group_notify` block fires after `presentationControllerDidDismiss:` has already consumed the callback → crash.
5. With the patch: `presentationControllerDidDismiss:` sets `photoSelected = YES`; the notify block early-returns → no crash.